### PR TITLE
docs: name the ERC20 allowance hazard at the saturation ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ over a tiny rounding/calculation slip; an underflow that wraps to "infinity" can
 cause approve/transfer of more than intended. Saturating arithmetic is the
 pragmatic guard: bounded mistakes stay bounded.
 
+The ceiling is `type(uint256).max`, which is also the ERC20 infinite allowance
+value, so a saturated `add` or `mul` result must be bounded against a balance or
+an explicit cap before it is used as an allowance.
+
 Saturating `add`, `sub`, `mul` are supported. `div` is not — `0/0` is undefined.
 
 ## Install

--- a/src/lib/LibSaturatingMath.sol
+++ b/src/lib/LibSaturatingMath.sol
@@ -12,10 +12,24 @@ pragma solidity ^0.8.18;
 /// Ideally there are no calculation mistakes, but in guarding against bugs it
 /// may be safer pragmatically to saturate arithmatic at the numeric bounds.
 /// Note that saturating div is not supported because 0/0 is undefined.
+///
+/// The ceiling that `saturatingAdd` and `saturatingMul` clamp to,
+/// `type(uint256).max`, is itself the canonical "infinite allowance" value in
+/// ERC20, which implementations following OpenZeppelin never decrement as it
+/// is spent. A saturated result is indistinguishable from one computed
+/// exactly, so nothing in it signals that the true value was out of range, and
+/// passing one to `approve` grants an unlimited allowance where unsaturated
+/// math would have reverted. Transfers are self limiting because a transfer of
+/// more than the balance reverts, but an allowance is a promise rather than a
+/// balance and nothing bounds it. Callers must bound a saturated result
+/// against something real, such as a balance or an explicit cap, before using
+/// it as an allowance.
 library LibSaturatingMath {
     /// Saturating addition.
     /// If the result of `a + b` overflows, the return value is the maximum
-    /// `uint256` value instead. This function does not revert.
+    /// `uint256` value instead. This function does not revert. That ceiling is
+    /// the ERC20 infinite allowance value; see the library notice before using
+    /// a saturated result as an allowance.
     /// @param a First term.
     /// @param b Second term.
     /// @return Minimum of (a + b) and max uint256.
@@ -40,7 +54,9 @@ library LibSaturatingMath {
 
     /// Saturating multiplication.
     /// If the result of `a * b` overflows, the return value is the maximum
-    /// `uint256` value instead. This function does not revert.
+    /// `uint256` value instead. This function does not revert. That ceiling is
+    /// the ERC20 infinite allowance value; see the library notice before using
+    /// a saturated result as an allowance.
     /// @param a First term.
     /// @param b Second term.
     /// @return Minimum of a * b and max uint256.


### PR DESCRIPTION
Closes #22.

Documentation only. `src/` executable logic is byte-identical to the
Protofire-audited commit; the diff is `@notice` prose plus a matching paragraph
in the README.

## Determination: **(b)** — the rationale is right but incomplete

#22 reads the `@notice` as arguing against the library's own behaviour.
Re-deriving it from the source, that is not quite what it does: each half of
the rationale is accurate for the function that answers it, and what is missing
is a caller-facing consequence of the ceiling.

**The rationale is not wrong, so this is not (a).** The sentence #22 quotes is
about the *underflow* direction specifically — "some calculation bug underflowed
zero". `saturatingSub` genuinely answers it: `0 - 1` in an `unchecked` block
wraps to `type(uint256).max`, and `saturatingSub` returns `0` instead. The
wrap-to-infinity hazard that sentence names is exactly the hazard `saturatingSub`
removes. There is no stale prose here to replace.

**But the ceiling is that same value, reached from the other side.**
`saturatingAdd` and `saturatingMul` clamp *up* to `type(uint256).max`, and in
ERC20 that value is not merely large, it is a sentinel. OpenZeppelin's
`_spendAllowance` is:

```solidity
uint256 currentAllowance = allowance(owner, spender);
if (currentAllowance < type(uint256).max) {
    ...check and decrement...
}
```

An allowance sitting at the ceiling is therefore never checked and never
decremented: unlimited and permanent. A consumer that computes an allowance
through `saturatingAdd`/`saturatingMul` converts what checked arithmetic would
have made a revert into exactly that, and the saturated value is
indistinguishable from one computed exactly, so nothing in the return signals
that a clamp happened.

**One point sharper than #22 puts it.** The rationale says "approve/transfer",
but only the *approve* half actually bites. A `transfer` of `type(uint256).max`
is self-limiting — the balance check reverts, nothing moves. An allowance is a
promise rather than a balance, so nothing bounds it. The caveat names that
asymmetry rather than repeating the rationale's pairing.

**Not (c).** There is no design question in the arithmetic. Clamping at the
numeric bound is what "saturating" means; a `saturatingAdd` that clamped
anywhere other than `type(uint256).max` would not be saturating addition. The
collision is a property of ERC20's choice of sentinel, not a defect in the
clamp, and it cannot be resolved inside a general-purpose `uint256` math
library — only by the caller, who alone knows what the number is for. So the
correct treatment is to state the caller's obligation, which is what #22's own
suggested fix proposes.

Severity is unchanged from #22: LOW / documentation.

## Before / after

Library `@notice`, unchanged text kept verbatim, appended paragraph:

```diff
 /// Note that saturating div is not supported because 0/0 is undefined.
+///
+/// The ceiling that `saturatingAdd` and `saturatingMul` clamp to,
+/// `type(uint256).max`, is itself the canonical "infinite allowance" value in
+/// ERC20, which implementations following OpenZeppelin never decrement as it
+/// is spent. A saturated result is indistinguishable from one computed
+/// exactly, so nothing in it signals that the true value was out of range, and
+/// passing one to `approve` grants an unlimited allowance where unsaturated
+/// math would have reverted. Transfers are self limiting because a transfer of
+/// more than the balance reverts, but an allowance is a promise rather than a
+/// balance and nothing bounds it. Callers must bound a saturated result
+/// against something real, such as a balance or an explicit cap, before using
+/// it as an allowance.
 library LibSaturatingMath {
```

`saturatingAdd` and `saturatingMul` each get a pointer, because tooling surfaces
function docs rather than the library title on a call site:

```diff
     /// If the result of `a + b` overflows, the return value is the maximum
-    /// `uint256` value instead. This function does not revert.
+    /// `uint256` value instead. This function does not revert. That ceiling is
+    /// the ERC20 infinite allowance value; see the library notice before using
+    /// a saturated result as an allowance.
```

`saturatingSub` is untouched — its floor is `0`, which carries no such hazard.

README, same point in the reader-facing summary:

```diff
+The ceiling is `type(uint256).max`, which is also the ERC20 infinite allowance
+value, so a saturated `add` or `mul` result must be bounded against a balance or
+an explicit cap before it is used as an allowance.
```

## Deployed bytecode is unchanged

Built at `main` (`e8d6da0`) and at this branch in two separate clean clones with
the pinned `sol-shell` toolchain (`forge 1.7.2-nightly`, `solc 0.8.25`, same
settings), comparing both `LibSaturatingMath` and `SaturatingMathHarness` — the
harness is the meaningful witness because `LibSaturatingMath` is `internal`-only,
so it is never deployed standalone and its code reaches chain inlined into a
consumer.

With `bytecode_hash = "none"`, artifacts are **byte-identical**:

| artifact | size | result |
| --- | --- | --- |
| `LibSaturatingMath` creation bytecode | 93 B | identical |
| `LibSaturatingMath` deployed bytecode | 43 B | identical |
| `SaturatingMathHarness` creation bytecode | 670 B | identical |
| `SaturatingMathHarness` deployed bytecode | 642 B | identical |

With the default `ipfs` metadata hash the only difference is the 32-byte source
digest inside the trailing CBOR blob, as expected, since that digest covers the
source text including comments:

| artifact | length | identical prefix | differing | identical suffix |
| --- | --- | --- | --- | --- |
| `LibSaturatingMath` creation | 135 B both | 93 B | 32 B | 11 B |
| `SaturatingMathHarness` deployed | 684 B both | 642 B | 32 B | 11 B |

The divergence begins immediately after `a2646970667358221220` (the CBOR `ipfs`
key and multihash header) and the run ends before `a164736f6c6343000819`, i.e.
it is contained entirely within the metadata digest. Every executable byte is
unchanged.

`src/` is also still logic-identical to `22e58d70`, the commit the January 2026
Protofire audit is anchored to: `git diff 22e58d70 HEAD -- src/` is comments
only, both before and after this PR.

`forge fmt` is a no-op over the change and the full suite passes: 25 passed,
0 failed.

## Consumer search

`saturatingAdd` / `saturatingMul` / `saturatingSub` / `LibSaturatingMath` /
`rain-math-saturating` searched across `rainlanguage`, `cyclofinance`,
`S01-Issuer` and `ST0x-Technology`. **No allowance or approval call site exists
anywhere in the org**, so nothing is live-affected and the severity stays where
#22 put it.

Every hit outside this repo:

- `rainlanguage/rain.math.fixedpoint` — the only real dependent
  (`rain-math-saturating~0.1.1`). It uses `saturatingMul` in
  `test/lib/LibFixedPointDecimalScaleSlow.sol`, a test-only slow reference
  implementation used as an oracle for `scaleUpSaturating`. The production
  `src/lib/LibFixedPointDecimalScale.sol` does not import this library at all;
  it implements its own saturation. Not allowance math, not production.
- `rainlanguage/rain-sketches` — `g7-lobby-grant/constraints.sol` calls
  `saturatingSub` on a share calculation. Sketch repo, and the floor direction,
  which is the safe one.

No hits at all in `cyclofinance`, `S01-Issuer` or `ST0x-Technology`.

## For the owner

One judgment call is worth naming, since #22 left it open: it offers
"reasonable to close as working-as-intended if the view is that this belongs in
consumer documentation rather than here". This PR takes the other side — the
library's own rationale is what invites the allowance use case, so the library
is where the caveat has to answer it, and a consumer cannot be relied on to read
docs it does not have. If you prefer it to live in consumer docs instead, revert
the `src/` hunks and keep the README one; the finding is the same either way.

This touches no test file, so it is independent of the pending #21 work.
